### PR TITLE
fix: only show first character of counter on each menu item

### DIFF
--- a/lib/food/widgets/menu_item.dart
+++ b/lib/food/widgets/menu_item.dart
@@ -1,3 +1,4 @@
+import 'package:characters/characters.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:hpi_flutter/core/localizations.dart';
@@ -36,7 +37,7 @@ class MenuItemView extends StatelessWidget {
             SizedBox(
               width: 32,
               child: Text(
-                showCounter ? item.counter : ' ',
+                showCounter ? item.counter.characters.first : ' ',
                 style:
                     Theme.of(context).textTheme.caption.copyWith(fontSize: 20),
               ),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -113,6 +113,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.0"
+  characters:
+    dependency: "direct main"
+    description:
+      name: characters
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.5.0"
   charcode:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,6 +11,7 @@ dependencies:
     sdk: flutter
 
   # General
+  characters: ^0.5.0
   kt_dart: ^0.6.2
 
   # Data


### PR DESCRIPTION
**Checklist**

- [x] Tested on actual devices

**Changes**
The menu items now only show the first character of the counter on the left side.